### PR TITLE
Rework derive logic

### DIFF
--- a/crates/anchor-idl/src/state.rs
+++ b/crates/anchor-idl/src/state.rs
@@ -70,7 +70,7 @@ pub fn generate_account(
 
     let acct_derive = if opts.zero_copy.is_none() && opts.representation.is_none() {
         quote! {
-            #[derive(AnchorSerialize, AnchorDeserialize, Debug, Clone)]
+            #[derive(AnchorSerialize, AnchorDeserialize, Clone)]
         }
     } else {
         quote! {}
@@ -87,7 +87,7 @@ pub fn generate_account(
         };
 
         quote! {
-            #[derive(AnchorSerialize, AnchorDeserialize, Debug)]
+            #[derive(AnchorSerialize, AnchorDeserialize)]
             #add_clone
         }
     } else {
@@ -101,9 +101,9 @@ pub fn generate_account(
         #zc_derive
         #repr_derive
         #acct_derive
-        // #derive_copy
         #derive_default
         #borsh_derive
+        #[derive(Debug)]
         pub struct #struct_name {
             #fields_rendered
         }

--- a/crates/anchor-idl/src/state.rs
+++ b/crates/anchor-idl/src/state.rs
@@ -17,13 +17,6 @@ pub fn generate_account(
 ) -> TokenStream {
     let props = get_field_list_properties(defs, fields);
 
-    let derive_copy = if props.can_copy && opts.zero_copy.is_none() {
-        quote! {
-            #[derive(Copy)]
-        }
-    } else {
-        quote! {}
-    };
     let derive_default = if props.can_derive_default {
         quote! {
             #[derive(Default)]
@@ -32,59 +25,85 @@ pub fn generate_account(
         quote! {}
     };
 
-    let derive_account = if let Some(zero_copy) = opts.zero_copy {
-        let zero_copy_quote = match zero_copy {
+    let zc_derive = if let Some(zero_copy) = opts.zero_copy {
+        match zero_copy {
             ZeroCopy::Safe => quote! {
                 #[zero_copy]
             },
             ZeroCopy::Unsafe => quote! {
                 #[zero_copy(unsafe)]
             },
-        };
-
-        if let Some(repr) = opts.representation {
-            let repr_quote = match repr {
-                crate::Representation::C => quote! {
-                    #[repr(C)]
-                },
-                crate::Representation::Transparent => quote! {
-                    #[repr(transparent)]
-                },
-                crate::Representation::Packed => quote! {
-                    #[repr(packed)]
-                },
-                crate::Representation::U8 => quote! {},
-                crate::Representation::U64 => quote! {},
-                crate::Representation::CPacked8 => quote! {
-                    #[repr(C, packed(8))]
-                },
-                crate::Representation::CPacked16 => quote! {
-                    #[repr(C, packed(16))]
-                },
-            };
-            quote! {
-                #zero_copy_quote
-                #repr_quote
-            }
-        } else {
-            zero_copy_quote
         }
     } else {
-        // Default to #[derive(Clone)] if zero_copy & repr are not set.
-        quote! {
-             #[account]
+        quote! {}
+    };
+
+    let repr_derive = if let Some(repr) = opts.representation {
+        match repr {
+            crate::Representation::C => quote! {
+                #[repr(C)]
+            },
+            crate::Representation::Transparent => quote! {
+                #[repr(transparent)]
+            },
+            crate::Representation::Packed => quote! {
+                #[repr(packed)]
+            },
+            crate::Representation::U8 => quote! {},
+            crate::Representation::U64 => quote! {},
+            crate::Representation::CPacked8 => quote! {
+                #[repr(C, packed(8))]
+            },
+            crate::Representation::CPacked16 => quote! {
+                #[repr(C, packed(16))]
+            },
+            crate::Representation::CAlign8 => quote! {
+                #[repr(C, align(8))]
+            },
+            crate::Representation::CAlign16 => quote! {
+                #[repr(C, align(16))]
+            },
         }
+    } else {
+        quote! {}
+    };
+
+    let acct_derive = if opts.zero_copy.is_none() && opts.representation.is_none() {
+        quote! {
+            #[derive(AnchorSerialize, AnchorDeserialize, Debug, Clone)]
+        }
+    } else {
+        quote! {}
+    };
+
+    let borsh_derive = if opts.can_borsh {
+        // Add Clone if zero_copy is not set. (zero_copy already adds Clone)
+        let add_clone = if opts.zero_copy.is_none() {
+            quote! {
+                #[derive(Clone)]
+            }
+        } else {
+            quote! {}
+        };
+
+        quote! {
+            #[derive(AnchorSerialize, AnchorDeserialize, Debug)]
+            #add_clone
+        }
+    } else {
+        quote! {}
     };
 
     // let doc = format!(" Account: {}", account_name);
     let struct_name = format_ident!("{}", account_name.to_pascal_case());
     let fields_rendered = generate_fields(fields);
     quote! {
-        #derive_account
-        // // #[doc = #doc]
-        #derive_copy
+        #zc_derive
+        #repr_derive
+        #acct_derive
+        // #derive_copy
         #derive_default
-        #[derive(Debug)]
+        #borsh_derive
         pub struct #struct_name {
             #fields_rendered
         }

--- a/crates/anchor-idl/src/state.rs
+++ b/crates/anchor-idl/src/state.rs
@@ -28,10 +28,10 @@ pub fn generate_account(
     let zc_derive = if let Some(zero_copy) = opts.zero_copy {
         match zero_copy {
             ZeroCopy::Safe => quote! {
-                #[zero_copy]
+                #[account(zero_copy)]
             },
             ZeroCopy::Unsafe => quote! {
-                #[zero_copy(unsafe)]
+                #[account(zero_copy(unsafe))]
             },
         }
     } else {

--- a/crates/anchor-idl/src/typedef.rs
+++ b/crates/anchor-idl/src/typedef.rs
@@ -241,7 +241,6 @@ pub fn generate_struct(
         #zc_derive
         #repr_derive
         #acct_derive
-        // #derive_copy
         #borsh_derive
         #derive_default
         #[derive(Debug)]

--- a/crates/anchor-idl/src/typedef.rs
+++ b/crates/anchor-idl/src/typedef.rs
@@ -167,60 +167,84 @@ pub fn generate_struct(
     } else {
         quote! {}
     };
-    let derive_serializers = if let Some(zero_copy) = opts.zero_copy {
-        let zero_copy_quote = match zero_copy {
+
+    let zc_derive = if let Some(zero_copy) = opts.zero_copy {
+        match zero_copy {
             crate::ZeroCopy::Unsafe => quote! {
                 #[zero_copy(unsafe)]
             },
             crate::ZeroCopy::Safe => quote! {
                 #[zero_copy]
             },
-        };
-        if let Some(repr) = opts.representation {
-            let repr_quote = match repr {
-                crate::Representation::C => quote! {
-                    #[repr(C)]
-                },
-                crate::Representation::Transparent => quote! {
-                    #[repr(transparent)]
-                },
-                crate::Representation::Packed => quote! {
-                    #[repr(packed)]
-                },
-                crate::Representation::U8 => quote! {},
-                crate::Representation::U64 => quote! {},
-                crate::Representation::CPacked8 => quote! {
-                    #[repr(C, packed(8))]
-                },
-                crate::Representation::CPacked16 => quote! {
-                    #[repr(C, packed(16))]
-                },
-            };
-            quote! {
-                #zero_copy_quote
-                #repr_quote
-            }
-        } else {
-            zero_copy_quote
         }
     } else {
-        let derive_copy = if props.can_copy {
+        quote! {}
+    };
+
+    let repr_derive = if let Some(repr) = opts.representation {
+        match repr {
+            crate::Representation::C => quote! {
+                #[repr(C)]
+            },
+            crate::Representation::Transparent => quote! {
+                #[repr(transparent)]
+            },
+            crate::Representation::Packed => quote! {
+                #[repr(packed)]
+            },
+            crate::Representation::U8 => quote! {},
+            crate::Representation::U64 => quote! {},
+            crate::Representation::CPacked8 => quote! {
+                #[repr(C, packed(8))]
+            },
+            crate::Representation::CPacked16 => quote! {
+                #[repr(C, packed(16))]
+            },
+            crate::Representation::CAlign8 => quote! {
+                #[repr(C, align(8))]
+            },
+            crate::Representation::CAlign16 => quote! {
+                #[repr(C, align(16))]
+            },
+        }
+    } else {
+        quote! {}
+    };
+
+    let acct_derive = if opts.zero_copy.is_none() && opts.representation.is_none() {
+        quote! {
+            #[derive(AnchorSerialize, AnchorDeserialize, Clone)]
+        }
+    } else {
+        quote! {}
+    };
+
+    let borsh_derive = if opts.can_borsh {
+        // Add Clone if zero_copy is not set. (zero_copy already adds Clone)
+        let add_clone = if opts.zero_copy.is_none() {
             quote! {
-                #[derive(Copy)]
+                #[derive(Clone)]
             }
         } else {
             quote! {}
         };
+        
         quote! {
-            #[derive(AnchorSerialize, AnchorDeserialize, Clone)]
-            #derive_copy
+            #[derive(AnchorSerialize, AnchorDeserialize)]
+            #add_clone
         }
+    } else {
+        quote! {}
     };
 
     quote! {
-        #derive_serializers
-        #[derive(Debug)]
+        #zc_derive
+        #repr_derive
+        #acct_derive
+        // #derive_copy
+        #borsh_derive
         #derive_default
+        #[derive(Debug)]
         pub struct #struct_name {
             #fields_rendered
         }


### PR DESCRIPTION
- Add `#[repr(C, align(NUM))]` options
- Remove adding of `repr(C)` only when `zero_copy` is used
- Remove deriving of `Copy` (unused and causes conflicts)